### PR TITLE
Integrate Stripe checkout with AWS secrets and OpenAI proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Next:
 2) cd ../frontend && npm i
 3) Fill env files (*.example → actual)
 4) Start: backend `npm run dev`, frontend `npm run dev`
+
+## Stripe configuration
+
+- Provide `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` as environment variables **or** expose them via AWS Secrets Manager using the ARN in `LUCIA_STRIPE_SECRET_ARN`.
+- Optional overrides: `STRIPE_SUCCESS_URL`, `STRIPE_CANCEL_URL`, `STRIPE_PORTAL_RETURN_URL`, `STRIPE_ALLOWED_PRICE_IDS`.
+- Frontend publishable key + price IDs go in `VITE_STRIPE_PUBLISHABLE_KEY` and `VITE_STRIPE_PRICE_*` env vars.
+
+## OpenAI proxy
+
+- Set `OPENAI_PROXY_URL` if you need to override the default Lambda URL.
+- Optionally set `LUCIA_OPENAI_PROMPT_SECRET` (Secrets Manager) or `OPENAI_SYSTEM_PROMPT` to inject the private system prompt when calling the proxy.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lucia-backend",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.609.0",
         "@aws-sdk/client-s3": "^3.609.0",
         "@aws-sdk/s3-request-presigner": "^3.609.0",
         "axios": "^1.7.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "start": "node src/server.js"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.609.0",
     "@aws-sdk/client-s3": "^3.609.0",
     "@aws-sdk/s3-request-presigner": "^3.609.0",
     "axios": "^1.7.4",

--- a/backend/src/lib/openai.js
+++ b/backend/src/lib/openai.js
@@ -1,5 +1,74 @@
-async function callOpenAI(prompt) {
-  // Dev-safe stub. Replace with real OpenAI client call in prod.
-  return `Echo: ${prompt.slice(0, 200)}`;
+const axios = require('axios');
+const { getSecretValue, parseSecretValue } = require('./secrets');
+
+let promptTemplatePromise = null;
+
+function getProxyUrl() {
+  return (process.env.OPENAI_PROXY_URL || 'https://tsqwdm45h22gxxvxoyflrpoj7m0eewmb.lambda-url.eu-west-1.on.aws/').trim();
 }
+
+async function loadPromptTemplate() {
+  if (!promptTemplatePromise) {
+    promptTemplatePromise = (async () => {
+      if (process.env.OPENAI_SYSTEM_PROMPT) {
+        return process.env.OPENAI_SYSTEM_PROMPT;
+      }
+      const secretId = (process.env.LUCIA_OPENAI_PROMPT_SECRET || '').trim();
+      if (!secretId) {
+        return null;
+      }
+      try {
+        const raw = await getSecretValue(secretId);
+        const parsed = parseSecretValue(raw);
+        if (!parsed) return null;
+        if (typeof parsed === 'string') return parsed;
+        return parsed.prompt || parsed.systemPrompt || null;
+      } catch (err) {
+        console.warn('Failed to load OpenAI prompt secret', err?.message);
+        return null;
+      }
+    })();
+  }
+  return promptTemplatePromise;
+}
+
+async function callOpenAI(prompt, options = {}) {
+  if (!prompt) {
+    throw new Error('Prompt is required');
+  }
+  const url = getProxyUrl();
+  if (!url) {
+    throw new Error('OpenAI proxy URL not configured');
+  }
+  const systemPrompt = await loadPromptTemplate();
+  const payload = {
+    prompt,
+    ...(systemPrompt ? { systemPrompt } : {}),
+    ...options,
+  };
+  try {
+    const response = await axios.post(url, payload, {
+      timeout: Number(process.env.OPENAI_PROXY_TIMEOUT_MS || 30000),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const data = response?.data;
+    if (!data) {
+      throw new Error('Empty response from OpenAI proxy');
+    }
+    if (typeof data === 'string') return data;
+    if (data.result) return data.result;
+    if (data.output) return data.output;
+    const choice = data.choices && data.choices[0];
+    if (choice?.message?.content) return choice.message.content;
+    if (choice?.text) return choice.text;
+    return JSON.stringify(data);
+  } catch (err) {
+    const message = err?.response?.data?.error || err?.message || 'OpenAI proxy request failed';
+    console.error('OpenAI proxy error', { message });
+    throw new Error(message);
+  }
+}
+
 module.exports = { callOpenAI };

--- a/backend/src/lib/secrets.js
+++ b/backend/src/lib/secrets.js
@@ -1,0 +1,49 @@
+const cache = new Map();
+
+async function loadSecretsManagerClient() {
+  try {
+    const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
+    const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || process.env.LUCIA_AWS_REGION || 'eu-west-1';
+    return { SecretsManagerClient, GetSecretValueCommand, region };
+  } catch (err) {
+    const hint = 'Install @aws-sdk/client-secrets-manager to enable secret retrieval';
+    const e = new Error(`${hint}: ${err.message}`);
+    e.cause = err;
+    e.code = 'secrets_manager_unavailable';
+    throw e;
+  }
+}
+
+async function getSecretValue(secretId) {
+  if (!secretId) {
+    throw new Error('Secret identifier is required');
+  }
+  if (cache.has(secretId)) {
+    return cache.get(secretId);
+  }
+  const { SecretsManagerClient, GetSecretValueCommand, region } = await loadSecretsManagerClient();
+  const client = new SecretsManagerClient({ region });
+  const command = new GetSecretValueCommand({ SecretId: secretId });
+  const data = await client.send(command);
+  let secret = data.SecretString;
+  if (!secret && data.SecretBinary) {
+    secret = Buffer.from(data.SecretBinary, 'base64').toString('utf-8');
+  }
+  cache.set(secretId, secret);
+  return secret;
+}
+
+function parseSecretValue(raw) {
+  if (raw == null) return null;
+  if (typeof raw !== 'string') return raw;
+  try {
+    return JSON.parse(raw);
+  } catch (_) {
+    return raw;
+  }
+}
+
+module.exports = {
+  getSecretValue,
+  parseSecretValue,
+};

--- a/backend/src/lib/stripe.js
+++ b/backend/src/lib/stripe.js
@@ -1,5 +1,234 @@
-async function createCheckoutSession(_payload) {
-  // Dev-safe stub. Replace with real Stripe SDK usage.
-  return { id: `cs_test_${Date.now()}` };
+const Stripe = require('stripe');
+const { getSecretValue, parseSecretValue } = require('./secrets');
+
+let stripeClientPromise = null;
+let stripeSecretsPromise = null;
+
+const DEFAULT_ALLOWED_PRICE_IDS = [
+  'prod_T94vRkqGFkaXWG',
+  'prod_T94zVM2gXLzNx3',
+  'prod_T950su3vUkpPAc',
+  'price_1SCmrg2NCNcgXLO1dIBQ75vR',
+];
+
+const allowedIds = new Set(
+  (process.env.STRIPE_ALLOWED_PRICE_IDS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+DEFAULT_ALLOWED_PRICE_IDS.forEach((id) => allowedIds.add(id));
+
+function getUrls() {
+  const successUrl = (process.env.STRIPE_SUCCESS_URL || 'https://www.luciadecode.com/success').trim();
+  const cancelUrl = (process.env.STRIPE_CANCEL_URL || 'https://www.luciadecode.com/cancel').trim();
+  const portalReturnUrl = (process.env.STRIPE_PORTAL_RETURN_URL || successUrl).trim();
+  return { successUrl, cancelUrl, portalReturnUrl };
 }
-module.exports = { createCheckoutSession };
+
+async function loadStripeSecrets() {
+  if (!stripeSecretsPromise) {
+    stripeSecretsPromise = (async () => {
+      const directKey = (process.env.STRIPE_SECRET_KEY || '').trim();
+      const directWebhook = (process.env.STRIPE_WEBHOOK_SECRET || '').trim();
+      if (directKey) {
+        return { secretKey: directKey, webhookSecret: directWebhook || null };
+      }
+      const secretId = (process.env.LUCIA_STRIPE_SECRET_ARN || '').trim();
+      if (!secretId) {
+        throw new Error('Stripe secret key not configured');
+      }
+      const rawSecret = await getSecretValue(secretId);
+      const parsed = parseSecretValue(rawSecret);
+      if (!parsed) {
+        throw new Error(`Secret ${secretId} returned empty value`);
+      }
+      if (typeof parsed === 'string') {
+        return { secretKey: parsed.trim(), webhookSecret: null };
+      }
+      const secretKey =
+        parsed.STRIPE_SECRET_KEY ||
+        parsed.secretKey ||
+        parsed.key ||
+        parsed.STRIPE_API_KEY ||
+        '';
+      const webhookSecret =
+        parsed.STRIPE_WEBHOOK_SECRET ||
+        parsed.webhookSecret ||
+        parsed.webhook ||
+        null;
+      if (!secretKey) {
+        throw new Error(`Secret ${secretId} does not contain a STRIPE_SECRET_KEY field`);
+      }
+      return { secretKey: secretKey.trim(), webhookSecret: webhookSecret ? webhookSecret.trim() : null };
+    })();
+  }
+  return stripeSecretsPromise;
+}
+
+async function getStripeClient() {
+  if (!stripeClientPromise) {
+    stripeClientPromise = (async () => {
+      const { secretKey } = await loadStripeSecrets();
+      const stripe = new Stripe(secretKey, {
+        apiVersion: process.env.STRIPE_API_VERSION || '2023-10-16',
+      });
+      return stripe;
+    })();
+  }
+  return stripeClientPromise;
+}
+
+function ensureAllowed(priceIdOrProductId) {
+  if (!allowedIds.size) return;
+  if (allowedIds.has(priceIdOrProductId)) return;
+  throw Object.assign(new Error(`Price or product not allowed: ${priceIdOrProductId}`), {
+    statusCode: 400,
+    code: 'price_not_allowed',
+  });
+}
+
+function escapeSearchTerm(term) {
+  return term.replace(/["']/g, ' ');
+}
+
+async function resolvePriceId(stripe, priceIdOrProductId) {
+  if (priceIdOrProductId.startsWith('price_')) {
+    return priceIdOrProductId;
+  }
+  if (!priceIdOrProductId.startsWith('prod_')) {
+    return priceIdOrProductId;
+  }
+  const product = await stripe.products.retrieve(priceIdOrProductId, {
+    expand: ['default_price'],
+  });
+  const defaultPrice = product?.default_price;
+  if (!defaultPrice) {
+    throw new Error(`Product ${priceIdOrProductId} has no default price`);
+  }
+  if (typeof defaultPrice === 'string') {
+    return defaultPrice;
+  }
+  if (defaultPrice && defaultPrice.id) {
+    return defaultPrice.id;
+  }
+  throw new Error(`Unable to resolve price for product ${priceIdOrProductId}`);
+}
+
+async function findCustomer(stripe, { uid, email }) {
+  const candidates = [];
+  if (uid) {
+    try {
+      const search = await stripe.customers.search({
+        query: `metadata['firebase_uid']:'${escapeSearchTerm(uid)}'`,
+        limit: 1,
+      });
+      if (search?.data?.length) {
+        candidates.push(...search.data);
+      }
+    } catch (err) {
+      if (err?.statusCode !== 404) {
+        console.warn('Stripe customer search failed, falling back to list', err.message);
+      }
+    }
+  }
+  if (!candidates.length && email) {
+    const list = await stripe.customers.list({ email, limit: 1 });
+    if (list?.data?.length) {
+      candidates.push(...list.data);
+    }
+  }
+  return candidates[0] || null;
+}
+
+async function getOrCreateCustomer(stripe, { uid, email }) {
+  const existing = await findCustomer(stripe, { uid, email });
+  if (existing) return existing;
+  const params = {
+    metadata: uid ? { firebase_uid: uid } : {},
+  };
+  if (email) params.email = email;
+  return stripe.customers.create(params);
+}
+
+async function createCheckoutSession({ priceId, uid, email }) {
+  if (!priceId) {
+    throw Object.assign(new Error('priceId is required'), { statusCode: 400 });
+  }
+  if (!uid) {
+    throw Object.assign(new Error('uid is required'), { statusCode: 400 });
+  }
+  ensureAllowed(priceId);
+  const stripe = await getStripeClient();
+  const resolvedPriceId = await resolvePriceId(stripe, priceId);
+  const customer = await getOrCreateCustomer(stripe, { uid, email });
+  const { successUrl, cancelUrl } = getUrls();
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    customer: customer.id,
+    client_reference_id: uid,
+    metadata: { firebase_uid: uid },
+    subscription_data: { metadata: { firebase_uid: uid } },
+    line_items: [{ price: resolvedPriceId, quantity: 1 }],
+    success_url: `${successUrl}?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: cancelUrl,
+    allow_promotion_codes: true,
+  });
+  return { id: session.id, url: session.url };
+}
+
+async function createPortalSession({ uid, email }) {
+  if (!uid && !email) {
+    throw Object.assign(new Error('uid or email is required to open the billing portal'), { statusCode: 400 });
+  }
+  const stripe = await getStripeClient();
+  const customer = await findCustomer(stripe, { uid, email });
+  if (!customer) {
+    const err = new Error('No Stripe customer found for user');
+    err.statusCode = 404;
+    err.code = 'customer_not_found';
+    throw err;
+  }
+  const { portalReturnUrl } = getUrls();
+  const session = await stripe.billingPortal.sessions.create({
+    customer: customer.id,
+    return_url: portalReturnUrl,
+  });
+  return { id: session.id, url: session.url };
+}
+
+async function verifyWebhookSignature(rawBody, signatureHeader) {
+  const { webhookSecret } = await loadStripeSecrets();
+  if (!webhookSecret) {
+    throw Object.assign(new Error('Stripe webhook secret not configured'), { statusCode: 500 });
+  }
+  const stripe = await getStripeClient();
+  return stripe.webhooks.constructEvent(rawBody, signatureHeader, webhookSecret);
+}
+
+async function handleWebhookEvent(event) {
+  const loggable = {
+    id: event?.id,
+    type: event?.type,
+  };
+  switch (event?.type) {
+    case 'checkout.session.completed':
+    case 'checkout.session.async_payment_succeeded':
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated':
+    case 'customer.subscription.deleted':
+    case 'invoice.payment_succeeded':
+    case 'invoice.payment_failed':
+      console.info('Stripe webhook received', loggable);
+      break;
+    default:
+      console.debug('Stripe webhook ignored', loggable);
+  }
+}
+
+module.exports = {
+  createCheckoutSession,
+  createPortalSession,
+  verifyWebhookSignature,
+  handleWebhookEvent,
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -6,18 +6,19 @@ const helmet = require('helmet');
 
 const securePrompts = require('./routes/securePrompts');
 const files = require('./routes/files');
-const payments = require('./routes/payments');
+const { router: stripeRouter, webhookHandler } = require('./routes/payments');
 
 const app = express();
 app.use(helmet());
-app.use(express.json({ limit: '1mb' }));
 app.use(cors({ origin: process.env.CORS_ORIGIN || true }));
+app.post('/stripe/webhook', express.raw({ type: 'application/json' }), webhookHandler);
+app.use(express.json({ limit: '1mb' }));
 
 app.get('/healthz', (_req, res) => res.status(200).json({ ok: true }));
 
 app.use('/api/secure-prompts', securePrompts);
 app.use('/api/files', files);
-app.use('/api/pay', payments);
+app.use('/stripe', stripeRouter);
 
 const port = process.env.PORT || 8080;
 app.listen(port, () => console.log(`API listening on :${port}`));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # High-level
-User → React (Vercel) → Node API (Render/Fly) → Vault (HCP) → OpenAI
-                                  ↘ S3 (encrypted) / Firebase / Stripe
+User → React (Vercel) → Node API (Render/Fly) → Vault (HCP) → AWS Lambda (OpenAI proxy)
+                                  ↘ S3 (encrypted) / Firebase / Stripe (Secrets Manager)
 
 No prompts/files in DB or logs. Secrets only in Vault. Backend reads at runtime.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -19,7 +19,7 @@ export function stripeEnabled() {
   return Boolean((import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || '').trim() && baseUrl());
 }
 
-export async function createCheckoutSession(priceId, uid) {
+export async function createCheckoutSession({ priceId, uid, email }) {
   const url = baseUrl() + '/stripe/create-checkout-session';
   const token = await getIdToken();
   const res = await fetch(url, {
@@ -28,13 +28,13 @@ export async function createCheckoutSession(priceId, uid) {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {})
     },
-    body: JSON.stringify({ priceId, uid })
+    body: JSON.stringify({ priceId, uid, email })
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json(); // { url }
 }
 
-export async function createPortalSession(uid) {
+export async function createPortalSession({ uid, email }) {
   const url = baseUrl() + '/stripe/create-portal-session';
   const token = await getIdToken();
   const res = await fetch(url, {
@@ -43,7 +43,7 @@ export async function createPortalSession(uid) {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {})
     },
-    body: JSON.stringify({ uid })
+    body: JSON.stringify({ uid, email })
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json(); // { url }

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -3,11 +3,18 @@ import { useAuthToken } from '../hooks/useAuthToken';
 import { createCheckoutSession, stripeEnabled } from '../lib/api';
 import '../styles/pricing.css';
 
+const PLAN_IDS = {
+  BASIC: import.meta.env.VITE_STRIPE_PRICE_BASIC || 'prod_T94vRkqGFkaXWG',
+  MEDIUM: import.meta.env.VITE_STRIPE_PRICE_MEDIUM || 'prod_T94zVM2gXLzNx3',
+  INTENSIVE: import.meta.env.VITE_STRIPE_PRICE_INTENSIVE || 'prod_T950su3vUkpPAc',
+  TOTAL: import.meta.env.VITE_STRIPE_PRICE_TOTAL || 'price_1SCmrg2NCNcgXLO1dIBQ75vR',
+};
+
 const PLANS = [
-  { key: 'BASIC',     name: 'Basic',     priceId: 'price_BASIC_EUR',     price: '€20',   note: '200 messages / mo' },
-  { key: 'MEDIUM',    name: 'Medium',    priceId: 'price_MEDIUM_EUR',    price: '€30',   note: '400 messages / mo' },
-  { key: 'INTENSIVE', name: 'Intensive', priceId: 'price_INTENSIVE_EUR', price: '€50',   note: '2,000 messages / mo' },
-  { key: 'TOTAL',     name: 'Total',     priceId: 'price_TOTAL_EUR',     price: '€90',   note: '6,000+ messages / mo' },
+  { key: 'BASIC', name: 'Basic', priceId: PLAN_IDS.BASIC, price: '€20', note: '200 messages / mo' },
+  { key: 'MEDIUM', name: 'Medium', priceId: PLAN_IDS.MEDIUM, price: '€30', note: '400 messages / mo' },
+  { key: 'INTENSIVE', name: 'Intensive', priceId: PLAN_IDS.INTENSIVE, price: '€50', note: '2,000 messages / mo' },
+  { key: 'TOTAL', name: 'Total', priceId: PLAN_IDS.TOTAL, price: '€90', note: '6,000+ messages / mo' },
 ];
 
 export default function Pricing({ onClose }) {
@@ -23,7 +30,7 @@ export default function Pricing({ onClose }) {
       alert('Owner must plug Stripe keys and API URL to enable checkout.');
       return;
     }
-    const { url } = await createCheckoutSession(priceId, user.uid);
+    const { url } = await createCheckoutSession({ priceId, uid: user.uid, email: user.email || undefined });
     window.location.href = url;
   }
 


### PR DESCRIPTION
## Summary
- wire the backend Stripe helpers to load secrets from AWS, create checkout/portal sessions, and verify webhooks
- expose new Stripe endpoints via Express and surface live price IDs in the pricing UI
- swap the OpenAI stub for the AWS Lambda proxy and document the new configuration knobs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68dc924112188333a5e156b5ade30700