### PR TITLE
Switch chat endpoint to OpenAI proxy

### DIFF
--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -1,0 +1,39 @@
+const router = require('express').Router();
+const { callOpenAI } = require('../lib/openai');
+
+function sanitizeHistory(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .slice(-20)
+    .map((entry) => {
+      const role = typeof entry?.role === 'string' ? entry.role : 'user';
+      const content = typeof entry?.content === 'string' ? entry.content : '';
+      return { role, content: content.trim() };
+    })
+    .filter((entry) => entry.content.length > 0);
+}
+
+router.post('/', async (req, res) => {
+  const prompt = (req.body?.prompt ?? '').toString();
+  if (!prompt.trim()) {
+    return res.status(400).json({ error: 'prompt_required' });
+  }
+
+  const history = sanitizeHistory(req.body?.history);
+  const options = {};
+  if (history.length > 0) {
+    options.history = history;
+    options.messages = [...history, { role: 'user', content: prompt }];
+  }
+
+  try {
+    const reply = await callOpenAI(prompt, options);
+    return res.json({ reply });
+  } catch (err) {
+    const message = err?.message || 'openai_request_failed';
+    console.error('Chat proxy failed', message);
+    return res.status(502).json({ error: 'openai_request_failed', message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 
 const securePrompts = require('./routes/securePrompts');
+const chat = require('./routes/chat');
 const files = require('./routes/files');
 const { router: stripeRouter, webhookHandler } = require('./routes/payments');
 
@@ -17,6 +18,7 @@ app.use(express.json({ limit: '1mb' }));
 app.get('/healthz', (_req, res) => res.status(200).json({ ok: true }));
 
 app.use('/api/secure-prompts', securePrompts);
+app.use('/api/chat', chat);
 app.use('/api/files', files);
 app.use('/stripe', stripeRouter);
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -11,7 +11,12 @@ export async function getIdToken() {
 function baseUrl() {
   const w = (import.meta.env.VITE_WORKER_API_URL || '').trim();
   const f = (import.meta.env.VITE_FUNCTIONS_URL || '').trim();
-  return w || f || ''; // same-origin if both blank
+  const raw = w || f || '';
+  return raw ? raw.replace(/\/+$/, '') : '';
+}
+
+export function apiBaseUrl() {
+  return baseUrl();
 }
 
 export function stripeEnabled() {

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -5,6 +5,7 @@ import Composer from "../components/Composer"
 import CourtesyPopup from "../components/CourtesyPopup"
 import { onQuickPrompt } from "../lib/bus"
 import { useAuthToken } from "../hooks/useAuthToken"
+import { apiBaseUrl, getIdToken } from "../lib/api"
 import {
   auth,
   db,
@@ -33,7 +34,7 @@ import "../styles/courtesy-popup.css"
 import { isSignInWithEmailLink, signInWithEmailLink } from "firebase/auth"
 import { doc, onSnapshot, getDoc, runTransaction } from "firebase/firestore"
 
-const WORKER_URL = "https://lucia-secure.arkkgraphics.workers.dev/chat"
+const CHAT_URL = `${apiBaseUrl() || ""}/api/chat`
 const DEFAULT_SYSTEM =
   "L.U.C.I.A. – Logical Understanding & Clarification of Interpersonal Agendas. She tells you what they want, what they're hiding, and what will actually work. Her value is context and strategy, not therapy. You are responsible for decisions."
 
@@ -304,11 +305,15 @@ async function send() {
     
     // FIXED: Convert messages to history format and use correct request format
     const history = msgs.map(m => ({ role: m.role, content: m.content }))
-    
-    const res = await fetch(WORKER_URL, {
+    const token = await getIdToken()
+
+    const res = await fetch(CHAT_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ 
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {})
+      },
+      body: JSON.stringify({
         prompt: content,      // ✅ Current user message
         history: history      // ✅ Previous conversation history
       })


### PR DESCRIPTION
## Summary
- add an Express chat route that forwards prompts to the OpenAI proxy Lambda with sanitized history
- expose a reusable API base helper for the frontend and trim trailing slashes
- update the chat UI to call the new backend route with optional auth tokens instead of the DeepSeek worker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc9fdc43f88333808ad17df1968cc3