### PR TITLE
Support /api/chat Cloudflare worker endpoint

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -2,8 +2,8 @@ Lucía Worker
 ============
 
 Endpoints:
-- GET / or /chat  -> health JSON
-- POST /chat      -> { prompt, history? } -> { reply }
+- GET / or /chat or /api/chat -> health JSON
+- POST /chat or /api/chat     -> { prompt, history? } -> { reply }
 
 Env (Dashboard -> Variables/Secrets):
 - DUMMY_MODE: "true" (echo) or "false" (DeepSeek)


### PR DESCRIPTION
## Summary
- normalize Cloudflare Worker routing so /chat and /api/chat share the same handler
- document the additional /api/chat health and chat endpoints in the worker README

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68dcacae42748333b74fb7f2780659da