### PR TITLE
Switch worker chat backend to OpenAI

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -6,7 +6,7 @@ Endpoints:
 - POST /chat or /api/chat     -> { prompt, history? } -> { reply }
 
 Env (Dashboard -> Variables/Secrets):
-- DUMMY_MODE: "true" (echo) or "false" (DeepSeek)
-- DEEPSEEK_API_URL: https://api.deepseek.com/v1/chat/completions
-- DEEPSEEK_MODEL: deepseek-chat
-- DEEPSEEK_API_KEY: (Secret)
+- DUMMY_MODE: "true" (echo) or "false" (OpenAI)
+- OPENAI_API_URL: https://api.openai.com/v1/chat/completions
+- OPENAI_MODEL: gpt-4o-mini
+- OPENAI_API_KEY: (Secret)

--- a/cloudflare-worker/src/worker.js
+++ b/cloudflare-worker/src/worker.js
@@ -17,7 +17,7 @@ export default {
       const info = {
         ok: true,
         service: "lucia-secure worker",
-        mode: env.DUMMY_MODE === "true" ? "DUMMY" : "DEEPSEEK",
+        mode: env.DUMMY_MODE === "true" ? "DUMMY" : "OPENAI",
         endpoint: "POST /chat or /api/chat { prompt, history? }"
       };
       return json(info, 200);
@@ -36,16 +36,16 @@ export default {
           return json({ reply: `Echo: ${prompt}` }, 200);
         }
 
-        // DeepSeek
-        const apiBase = env.DEEPSEEK_API_URL || "https://api.deepseek.com/v1/chat/completions";
+        // OpenAI
+        const apiBase = env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions";
         const res = await fetch(apiBase, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${env.DEEPSEEK_API_KEY}`
+            "Authorization": `Bearer ${env.OPENAI_API_KEY}`
           },
           body: JSON.stringify({
-            model: env.DEEPSEEK_MODEL || "deepseek-chat",
+            model: env.OPENAI_MODEL || "gpt-4o-mini",
             messages: [...history, { role: "user", content: prompt }],
             temperature: 0.7
           })

--- a/cloudflare-worker/src/worker.mjs
+++ b/cloudflare-worker/src/worker.mjs
@@ -29,7 +29,7 @@ async function handleIp(request) {
   return json({ ip });
 }
 
-// FIXED: Real chat handler with DeepSeek integration
+// FIXED: Real chat handler with OpenAI integration
 async function handleChat(request, origin, env) {
   try {
     const body = await request.json();
@@ -43,16 +43,16 @@ async function handleChat(request, origin, env) {
       return json({ reply: `Echo: ${prompt}` }, origin, 200);
     }
 
-    // DeepSeek API call
-    const apiBase = env.DEEPSEEK_API_URL || "https://api.deepseek.com/v1/chat/completions";
+    // OpenAI API call
+    const apiBase = env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions";
     const res = await fetch(apiBase, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `Bearer ${env.DEEPSEEK_API_KEY}`
+        "Authorization": `Bearer ${env.OPENAI_API_KEY}`
       },
       body: JSON.stringify({
-        model: env.DEEPSEEK_MODEL || "deepseek-chat",
+        model: env.OPENAI_MODEL || "gpt-4o-mini",
         messages: [...history, { role: "user", content: prompt }],
         temperature: 0.7
       })
@@ -92,7 +92,7 @@ export default {
         {
           ok: true,
           service: "lucia-secure worker",
-          mode: env.DUMMY_MODE === "true" ? "DUMMY" : "DEEPSEEK",
+          mode: env.DUMMY_MODE === "true" ? "DUMMY" : "OPENAI",
           endpoints: ["GET /ip", "POST /chat", "GET /health"],
         },
         origin,
@@ -100,7 +100,7 @@ export default {
       );
     }
 
-    // Chat with real DeepSeek integration
+    // Chat with OpenAI integration
     if (request.method === "POST" && url.pathname === "/chat") {
       return handleChat(request, origin, env);
     }

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -6,5 +6,5 @@ workers_dev = true
 
 [vars]
 # Optional defaults (you can override in dashboard)
-DEEPSEEK_MODEL = "deepseek-reasoner"
+OPENAI_MODEL = "gpt-4o-mini"
 ALLOW_ORIGIN = "*"


### PR DESCRIPTION
## Summary
- update the Cloudflare worker chat handler to use the OpenAI chat completions API and env vars
- refresh worker configuration defaults and documentation to reference the OpenAI model

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dcaed29b7c83338f828ada7c5f8ce5