### PR TITLE
Fix chat API URL resolution for configurable bases

### DIFF
--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ import Composer from "../components/Composer"
 import CourtesyPopup from "../components/CourtesyPopup"
 import { onQuickPrompt } from "../lib/bus"
 import { useAuthToken } from "../hooks/useAuthToken"
-import { apiBaseUrl, getIdToken } from "../lib/api"
+import { chatUrl, getIdToken } from "../lib/api"
 import {
   auth,
   db,
@@ -34,7 +34,7 @@ import "../styles/courtesy-popup.css"
 import { isSignInWithEmailLink, signInWithEmailLink } from "firebase/auth"
 import { doc, onSnapshot, getDoc, runTransaction } from "firebase/firestore"
 
-const CHAT_URL = `${apiBaseUrl() || ""}/api/chat`
+const CHAT_URL = chatUrl()
 const DEFAULT_SYSTEM =
   "L.U.C.I.A. – Logical Understanding & Clarification of Interpersonal Agendas. She tells you what they want, what they're hiding, and what will actually work. Her value is context and strategy, not therapy. You are responsible for decisions."
 


### PR DESCRIPTION
## Summary
- add a chatUrl helper so the frontend can safely derive the chat endpoint from configurable API bases
- allow an explicit VITE_CHAT_URL override to point directly at a custom OpenAI proxy
- update the chat page to use the new helper instead of concatenating /api/chat manually

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68dcb0d99fe88333be7855a78b6915d6