### PR TITLE
Ensure proxy returns reply text

### DIFF
--- a/infra/aws/lucia-openai-proxy/index.mjs
+++ b/infra/aws/lucia-openai-proxy/index.mjs
@@ -177,5 +177,22 @@ export const handler = async (event) => {
     return jsonResponse(statusCode, upstream);
   }
 
-  return jsonResponse(200, { ok: true, data: upstream.data });
+  const firstChoice = upstream.data?.choices?.[0];
+  const reply =
+    typeof firstChoice?.message?.content === "string"
+      ? firstChoice.message.content
+      : typeof firstChoice?.text === "string"
+      ? firstChoice.text
+      : null;
+
+  if (reply === null) {
+    return jsonResponse(502, {
+      ok: false,
+      code: "upstream_error",
+      reason: "Upstream response did not include a reply text.",
+      data: upstream.data,
+    });
+  }
+
+  return jsonResponse(200, { ok: true, reply, data: upstream.data });
 };


### PR DESCRIPTION
## Summary
- extract the first choice message text from successful OpenAI responses
- surface the extracted reply alongside the original upstream payload for debugging
- fail with an upstream error if no reply text is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4bb54bea88333a9049eafd58c5f2b